### PR TITLE
remote tile details added

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "env-cmd -f .env.production react-scripts --openssl-legacy-provider start",
+    "start": "env-cmd -f .env.development react-scripts --openssl-legacy-provider start",
     "build": "react-scripts --openssl-legacy-provider build",
     "build:development": "env-cmd -f .env.development npm run build",
     "build:production": "env-cmd -f .env.production npm run build",

--- a/src/components/meeting/SpeakerLayout/index.js
+++ b/src/components/meeting/SpeakerLayout/index.js
@@ -40,7 +40,7 @@ const SpeakerLayout = ({dominantSpeakerId}) => {
         isPresenter = false;
     }
     participantTracks = remoteTracks[largeVideoId];
-    participantDetails =  conference.participants[largeVideoId]?._identity?.user; 
+    participantDetails =  conference.participants.get(largeVideoId)?._identity?.user; 
 
     if (largeVideoId === conference.myUserId()){
         participantTracks = localTracks;

--- a/src/components/shared/ConnectionIndicator/index.js
+++ b/src/components/shared/ConnectionIndicator/index.js
@@ -131,7 +131,7 @@ const ConnectionIndicator = ({ participantId }) => {
       ? conference.connectionQuality._localStats
       : conference.connectionQuality._remoteStats[participantId] || {};
   const connectionStatus =
-    conference.participants[participantId]?.getConnectionStatus();
+    conference.participants.get(participantId)?.getConnectionStatus();
 
   const connectionSvgIcon = (
     <SignalCellularAltIcon  className={classes.icon} />

--- a/src/components/shared/ParticipantDetails/index.js
+++ b/src/components/shared/ParticipantDetails/index.js
@@ -178,7 +178,7 @@ const togglePinParticipant = (id) => {
 }
 
 const getAvatarColor =  (id)=> {
-    return conference.participants[id]?._identity?.user?.avatar || profile?.color;
+    return conference.participants.get(id)?._identity?.user?.avatar || profile?.color;
 }
 
   return (


### PR DESCRIPTION
Due to changes in the SMT, remote participant tile was not showing participant name & avatar with initials.
Incorporated the SMT changes